### PR TITLE
Add Player delete method with tests

### DIFF
--- a/lib/one_signal/player.rb
+++ b/lib/one_signal/player.rb
@@ -45,7 +45,7 @@ module OneSignal
       uri_string += "/players"
       uri_string += "/#{id}"
       uri = URI.parse(uri_string)
-    
+
       response = send_get_request(uri: uri, params: nil, opts: opts)
 
       ensure_http_status(response: response,
@@ -150,6 +150,25 @@ module OneSignal
                          method_name: 'Update',
                          uri: uri,
                          params: params)
+
+      return response
+    end
+
+    def self.delete(id: "", opts: {})
+      opts[:auth_key] ||= @@api_key
+
+      uri_string = @@base_uri
+      uri_string += "/players"
+      uri_string += "/#{id}"
+      uri = URI.parse(uri_string)
+
+      response = send_delete_request(uri: uri, params: nil, opts: opts)
+
+      ensure_http_status(response: response,
+                         status: '200',
+                         method_name: 'Delete',
+                         uri: uri,
+                         params: nil)
 
       return response
     end

--- a/one_signal.gemspec
+++ b/one_signal.gemspec
@@ -2,7 +2,7 @@ require File.expand_path('lib/one_signal/version')
 
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
-  s.add_development_dependency 'rake', '~> 10.4'
+  s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'dotenv', '~> 2.0'
   s.add_development_dependency 'minitest', '~> 5.8'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'one_signal'
 
 def mock_response_ok

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -10,6 +10,7 @@ class PlayerTest < MiniTest::Test
     @player_id = "fake-id-123"
     @get_uri = URI.parse(base_url + "/#{@player_id}")
     @update_uri = URI.parse(base_url + "/#{@player_id}")
+    @delete_uri = URI.parse(base_url + "/#{@player_id}")
     @create_session_uri = URI.parse(base_url + "/#{@player_id}/on_session")
     @create_purchase_uri = URI.parse(base_url + "/#{@player_id}/on_purchase")
     @create_focus_uri = URI.parse(base_url + "/#{@player_id}/on_focus")
@@ -192,6 +193,22 @@ class PlayerTest < MiniTest::Test
     assert_equal response, OneSignal::Player.create_focus(id: @player_id,
                                                           params: @params,
                                                           opts: @opts)
+  end
+
+  def test_delete
+    response = mock_response_ok
+    OneSignal::OneSignal.expects(:send_delete_request)
+                        .with(uri: @delete_uri, params: nil, opts: @default_opts)
+                        .returns(response)
+    assert_equal response, OneSignal::Player.delete(id: @player_id)
+  end
+
+  def test_delete_with_auth_key
+    response = mock_response_ok
+    OneSignal::OneSignal.expects(:send_delete_request)
+                        .with(uri: @delete_uri, params: nil, opts: @opts)
+                        .returns(response)
+    assert_equal response, OneSignal::Player.delete(id: @player_id, opts: @opts)
   end
 
 end


### PR DESCRIPTION
This adds a delete method on `Player` with tests so a single player can be deleted by id. This follows the same approach as used in `Notification` since it has a delete method but in this case no params are supported.

This includes 2 commits from #17 so the tests will run. We should review and merge #17 first to make sure it's running successfully in CI. I'll then rebase this to remove the cherry picked commits.

https://documentation.onesignal.com/docs/delete-users#api-deletion-requirements