### PR TITLE
Fix player delete method to include params

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+=== 1.2.2 2021-09-02
+
+* Fix delete a player method to include `params` argument: https://github.com/tbalthazar/onesignal-ruby/pull/20
+
 === 1.2.1 2021-09-01
 
 * Add a method to delete a player: https://github.com/tbalthazar/onesignal-ruby/pull/18
@@ -16,7 +20,7 @@
 
 === 0.0.14 2016-02-22
 
-* Change ruby required version from 2.2.0 to 2.1.0 
+* Change ruby required version from 2.2.0 to 2.1.0
 
 === 0.0.13 2016-02-18
 

--- a/lib/one_signal/player.rb
+++ b/lib/one_signal/player.rb
@@ -154,7 +154,7 @@ module OneSignal
       return response
     end
 
-    def self.delete(id: "", opts: {})
+    def self.delete(id: "", params: {}, opts: {})
       opts[:auth_key] ||= @@api_key
 
       uri_string = @@base_uri
@@ -162,7 +162,7 @@ module OneSignal
       uri_string += "/#{id}"
       uri = URI.parse(uri_string)
 
-      response = send_delete_request(uri: uri, params: nil, opts: opts)
+      response = send_delete_request(uri: uri, params: params, opts: opts)
 
       ensure_http_status(response: response,
                          status: '200',

--- a/lib/one_signal/version.rb
+++ b/lib/one_signal/version.rb
@@ -1,3 +1,3 @@
 module OneSignal
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -198,17 +198,20 @@ class PlayerTest < MiniTest::Test
   def test_delete
     response = mock_response_ok
     OneSignal::OneSignal.expects(:send_delete_request)
-                        .with(uri: @delete_uri, params: nil, opts: @default_opts)
+                        .with(uri: @delete_uri, params: @params, opts: @default_opts)
                         .returns(response)
-    assert_equal response, OneSignal::Player.delete(id: @player_id)
+    assert_equal response, OneSignal::Player.delete(id: @player_id,
+                                                    params: @params)
   end
 
   def test_delete_with_auth_key
     response = mock_response_ok
     OneSignal::OneSignal.expects(:send_delete_request)
-                        .with(uri: @delete_uri, params: nil, opts: @opts)
+                        .with(uri: @delete_uri, params: @params, opts: @opts)
                         .returns(response)
-    assert_equal response, OneSignal::Player.delete(id: @player_id, opts: @opts)
+    assert_equal response, OneSignal::Player.delete(id: @player_id,
+                                                    params: @params,
+                                                    opts: @opts)
   end
 
 end


### PR DESCRIPTION
When working on #18 I made a mistake with the `params` usage and thought it wasn't needed. This argument is required to provide the `app_id` for a delete request which I missed on the documentation. Sorry about that!