### PR TITLE
Add player delete method to README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The return value of each method is a `Net::HTTPResponse`.
 - OneSignal::Player.create_purchase(id:, params:)
 - OneSignal::Player.create_focus(id:, params:)
 - OneSignal::Player.update(id:, params:)
+- OneSignal::Player.delete(id:, params:)
 ```
 
 ### Notifications
@@ -103,4 +104,4 @@ They are [listed here](https://github.com/tbalthazar/onesignal-ruby/graphs/contr
 
 ## License
 
-Please see [LICENSE](/LICENSE) for licensing details. 
+Please see [LICENSE](/LICENSE) for licensing details.


### PR DESCRIPTION
This updates the API methods list in the README with the new `OneSignal::Player.delete` method.