### PR TITLE
Add `bin/setup` and `bin/console` scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,22 @@ gem install one_signal
 
 ## Development
 
+Run `bin/setup` to install dependencies and set your API keys.
+
 Run the tests
 
 ```
 bundle exec rake
 ```
 
+You can also run `bin/console` for an interactive prompt that will allow you to experiment with authenticated library methods.
+
 ## Basic usage
 
-See basic examples in [example.rb](/example.rb).
+See some basic examples in [example.rb](/example.rb).
 To run it:
-- rename [.env.example](/.env.example) into `.env`
-- set your `USER_AUTH_KEY` and `API_KEY` in the `.env` file
-- run `ruby example.rb`
+- run `bin/setup` to set your API keys
+- then run `ruby example.rb`
 
 ## Documentation
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "dotenv/load"
+require "one_signal"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+OneSignal::OneSignal.user_auth_key = ENV['USER_AUTH_KEY']
+OneSignal::OneSignal.api_key = ENV['API_KEY']
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+echo "Enter your OneSignal credentials."
+echo "For dealing with Apps, you'll need a user auth key."
+read -p 'User Auth Key: ' user_auth_key
+echo "For dealing with Players and Notifications, you'll need an API key."
+read -p 'API Key: ' api_key
+
+cp .env.example .env
+
+sed -i '' -e "s/YOUR_USER_AUTH_KEY_HERE/$user_auth_key/g" .env
+sed -i '' -e "s/YOUR_API_KEY_HERE/$api_key/g" .env
+
+echo "Done."


### PR DESCRIPTION
These bin scripts come as a default when creating a gem. They are helpful in automating gem setup for development and for an interactive prompt for experimenting with library changes. I find the latter most helpful especially with libraries like this one. I've used it already to try out the new player delete method and how to handle errors.