### PR TITLE
Push to rubygems manually

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,8 +1,7 @@
 name: Ruby Gem
 
 on:
-  push:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
We don't want to automatically push each time a change is made to master. We only want to push when the gem version changed. We could script that, but for the sake of simplicity, let's make this a manually triggered action for now.