### PR TITLE
Store original message in error exception

### DIFF
--- a/lib/one_signal/errors/one_signal_error.rb
+++ b/lib/one_signal/errors/one_signal_error.rb
@@ -1,11 +1,13 @@
 module OneSignal
   class OneSignalError < StandardError
     attr_reader :message
+    attr_reader :original_message
     attr_reader :http_status
     attr_reader :http_body
 
     def initialize(message: nil, http_status: nil, http_body: nil)
       @message = message
+      @original_message = message
       @http_status = http_status
       @http_body = http_body
       @message += " - http status : #{@http_status}" unless @http_status.nil?


### PR DESCRIPTION
In OneSignal, when raise error 500, the http body is a HTML page with error. Adding this page to message is very unuseful to display a simple error message. Storing the original message allow us to retrieve it using `exception.original_message` instead of `exception.message`.